### PR TITLE
feat: add Google Analytics event tracking

### DIFF
--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,5 +1,12 @@
 import { track } from '@vercel/analytics';
 
+// Google Analytics helper
+const gtag = (...args: any[]) => {
+  if (typeof window !== 'undefined' && (window as any).gtag) {
+    (window as any).gtag(...args);
+  }
+};
+
 // Article engagement events
 export const trackArticleClick = (articleData: {
   title: string;
@@ -16,6 +23,11 @@ export const trackArticleClick = (articleData: {
     hype_meter: articleData.hype_meter || 0,
     timestamp: new Date().toISOString()
   });
+  gtag('event', 'article_click', {
+    article_title: articleData.title,
+    source: articleData.source,
+    category: articleData.category,
+  });
 };
 
 // Lens switching (Simple/PM/Engineer views)
@@ -24,6 +36,10 @@ export const trackLensSwitch = (lens: string, articleTitle: string) => {
     lens_type: lens,
     article_title: articleTitle,
     timestamp: new Date().toISOString()
+  });
+  gtag('event', 'lens_switch', {
+    lens_type: lens,
+    article_title: articleTitle,
   });
 };
 
@@ -34,6 +50,10 @@ export const trackSignupClick = () => {
     cta_text: 'Join the Journey',
     timestamp: new Date().toISOString()
   });
+  gtag('event', 'signup_click', {
+    location: 'footer',
+    cta_text: 'Join the Journey',
+  });
 };
 
 // Scroll tracking
@@ -43,6 +63,9 @@ export const trackScrollDepth = (depth: number) => {
     articles_visible: Math.floor(depth / 10), // Approximate
     timestamp: new Date().toISOString()
   });
+  gtag('event', 'scroll', {
+    percent_scrolled: depth,
+  });
 };
 
 // Category interest (for future filters)
@@ -50,5 +73,8 @@ export const trackCategoryView = (category: string) => {
   track('category_viewed', {
     category_name: category,
     timestamp: new Date().toISOString()
+  });
+  gtag('event', 'view_category', {
+    category_name: category,
   });
 };


### PR DESCRIPTION
## Summary
- add GA helper gtag to safely call window.gtag
- send GA events for article clicks, lens switches, signups, scroll depth and category views

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689e25952cc0833295b5d4ff902442ae