### PR TITLE
feat: update share button

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -41,11 +41,6 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       
-      - name: Add Share IDs to Articles
-        run: |
-          echo "=== ADDING SHARE IDs ==="
-          node scripts/addIds.mjs
-          echo "=== SHARE IDs ADDED ==="
           
       - name: Show what changed
         run: |

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -152,23 +152,24 @@ export default function Card({ item }: { item: any }) {
           </time>
           
           {/* Mobile-only share button */}
-          {isMobile && (
+          {isMobile && item.share_id && (
             <button
               onClick={handleShare}
               className="p-2 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
               aria-label="Share article"
             >
-              <svg 
-                className="w-4 h-4 text-gray-500 dark:text-gray-400" 
-                fill="none" 
-                stroke="currentColor" 
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
                 viewBox="0 0 24 24"
+                strokeWidth="1.5"
+                stroke="currentColor"
+                className="w-5 h-5 text-gray-500 dark:text-gray-400"
               >
-                <path 
-                  strokeLinecap="round" 
-                  strokeLinejoin="round" 
-                  strokeWidth={2} 
-                  d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m9.032 4.024a3 3 0 004.243 4.243m0 0a3 3 0 10-4.243-4.243m4.243 4.243L12 12"
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z"
                 />
               </svg>
             </button>


### PR DESCRIPTION
## Summary
- only show share button on mobile when article has `share_id`
- swap share icon for a more visible design
- remove unused Share IDs step from daily ingest workflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a31f42285083329983299329a78ac4