### PR TITLE
Include share IDs when loading cached articles

### DIFF
--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -232,6 +232,7 @@ async function loadAllCachedArticles(cacheDir) {
         // Build record from cached data
         records.push({
           id: cached.content_hash,
+          share_id: cached.share_id,
           category: cached.category,
           title: cached.title,
           source: cached.source,
@@ -323,6 +324,7 @@ async function main() {
             const cached = JSON.parse(await fs.readFile(cachePath, 'utf8'));
             records.push({
               id: hash,
+              share_id: cached.share_id,
               category: cached.category,
               title: cached.title,
               source: cached.source,


### PR DESCRIPTION
## Summary
- ensure ingest script preserves share_id when loading article records from cache

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3fb1ee3c0833290bd1e61b2e69387