### PR TITLE
feat: add SimpleHeader to pattern and article pages

### DIFF
--- a/app/article/[id]/page.tsx
+++ b/app/article/[id]/page.tsx
@@ -4,6 +4,7 @@ import path from 'path'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 import Card from '@/components/Card'
+import SimpleHeader from '@/components/SimpleHeader'
 
 // Get article by ID (either regular ID or share_id)
 async function getArticle(id: string) {
@@ -36,6 +37,8 @@ export default async function ArticlePage({
   
   return (
     <main className="max-w-3xl mx-auto">
+      {/* Add header for article page */}
+      <SimpleHeader />
       {/* Back button */}
       <div className="mb-6">
         <Link 

--- a/app/pattern/latest/page.tsx
+++ b/app/pattern/latest/page.tsx
@@ -3,6 +3,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
+import SimpleHeader from '@/components/SimpleHeader'
 
 // Get the latest pattern
 async function getLatestPattern() {
@@ -47,6 +48,8 @@ export default async function PatternLatestPage() {
   
   return (
     <main className="max-w-4xl mx-auto">
+      {/* Add header for pattern page */}
+      <SimpleHeader />
       {/* Back button */}
       <div className="mb-6">
         <Link 


### PR DESCRIPTION
## Summary
- include the SimpleHeader component on the pattern latest page
- include the SimpleHeader component on article detail pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac6029d2988332aa1634912e87361b